### PR TITLE
Fixed documentation and inheritance issues with IManagedProcess

### DIFF
--- a/BassClefStudio.NET.Processes/BassClefStudio.NET.Processes.csproj
+++ b/BassClefStudio.NET.Processes/BassClefStudio.NET.Processes.csproj
@@ -8,6 +8,7 @@
     <RepositoryUrl>https://github.com/bassclefstudio/.NET-Processes.git</RepositoryUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Provides helper classes for dealing with common scenarios involving the Process class, including shell and command-line execution and managing standard I/O.</Description>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BassClefStudio.NET.Processes/CommandLineProcess.cs
+++ b/BassClefStudio.NET.Processes/CommandLineProcess.cs
@@ -10,7 +10,7 @@ namespace BassClefStudio.NET.Processes
     /// <summary>
     /// Manages calls to a single command-line application and provides methods for dealing with input and output in a more streamlined manner.
     /// </summary>
-    public class CommandLineProcess : IDisposable
+    public class CommandLineProcess : IManagedProcess
     {
         /// <inheritdoc/>
         public Process MyProcess { get; private set; }
@@ -45,10 +45,10 @@ namespace BassClefStudio.NET.Processes
         private TaskCompletionSource<int> ExitedSource { get; set; }
 
         /// <inheritdoc/>
-        public async Task<int> CallCommandAsync(string command)
+        public async Task<int> CallAsync(string arguments)
         {
             MyProcess.Refresh();
-            MyProcess.StartInfo.Arguments = command;
+            MyProcess.StartInfo.Arguments = arguments;
             ExitedSource = new TaskCompletionSource<int>();
             MyProcess.Start();
             return await ExitedSource.Task;

--- a/BassClefStudio.NET.Processes/IManagedProcess.cs
+++ b/BassClefStudio.NET.Processes/IManagedProcess.cs
@@ -18,11 +18,11 @@ namespace BassClefStudio.NET.Processes
         Process MyProcess { get; }
 
         /// <summary>
-        /// Calls the given command asynchronously and monitors standard I/O.
+        /// Calls the process asynchronously and monitors standard I/O.
         /// </summary>
-        /// <param name="command">The shell script to execute.</param>
-        /// <returns>The exit code returned by the exiting process.</returns>
-        Task<int> CallCommandAsync(string command);
+        /// <param name="arguments">The parameters provided to the process when it is launched.</param>
+        /// <returns>The exit code returned by the process.</returns>
+        Task<int> CallAsync(string arguments);
 
         /// <summary>
         /// Writes the given line to the attached <see cref="Process.StandardInput"/>.

--- a/BassClefStudio.NET.Processes/ShellProcess.cs
+++ b/BassClefStudio.NET.Processes/ShellProcess.cs
@@ -43,7 +43,7 @@ namespace BassClefStudio.NET.Processes
         private TaskCompletionSource<int> ExitedSource { get; set; }
 
         /// <inheritdoc/>
-        public async Task<int> CallCommandAsync(string command)
+        public async Task<int> CallAsync(string command)
         {
             MyProcess.Refresh();
             MyProcess.StartInfo.Arguments = command;


### PR DESCRIPTION
`IManagedProcess` is now implemented by both `ShellProcess` and `CommandLineProcess`, and the `CallAsync(string)` method now has more generic documentation that applies to both instances.